### PR TITLE
Origin/feature/player stats

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1,0 +1,57 @@
+enum InnatePlayerStats {
+    Boldness = "Boldness",
+    Intelligence = "Intelligence",
+    Intuition = "Intuition",
+    Charisma = "Charisma",
+    Dexterity = "Dexterity",
+    Constitution = "Constitution",
+    Strength = "Strength",
+}
+
+enum CalculatedPlayerStats {
+    HP = "HP",
+    BendingEnergy = "BendingEnergy",
+    Toughness = "Toughness",
+    Dodge = "Dodge",
+    Initiative = "Initiative",
+    Damage = "Damage",
+}
+
+type PlayerStats = {
+    [key in InnatePlayerStats | CalculatedPlayerStats]: number;
+};
+
+export class Player {
+    stats: PlayerStats;
+
+    initializeStats() {
+       Object.values(InnatePlayerStats).forEach((stat) => { this.stats[stat] = 1; });
+    }
+
+    levelUpStats() {
+        Object.values(InnatePlayerStats).forEach((stat) => { this.stats[stat] += Math.round(Math.random()); });
+    }
+
+    evaluateCalculatedStats() {
+        // TODO: Consider Stats from Items
+        // HP
+        this.stats.HP = 8 + this.stats.Constitution + this.stats.Strength;
+
+        // Bending Energy
+        this.stats.BendingEnergy =
+         (this.stats.Constitution * (this.stats.Intuition + this.stats.Intelligence + this.stats.Dexterity)) / 6;
+
+        // Tougness - TODO: divide by 100 to have a percentage?
+        this.stats.Toughness = this.stats.Dexterity + (this.stats.Constitution * 2 + this.stats.Strength) / 6;
+
+        // Dodge - TODO: divie by 100 do have a percentage?
+        this.stats.Dodge = this.stats.Dexterity / 2;
+
+        // Initiative
+        this.stats.Initiative = (this.stats.Boldness + this.stats.Dexterity) / 2;
+
+        // Damage - TODO: Change formula to updated version
+        this.stats.Damage =
+         (0.1 * this.stats.Boldness + this.stats.Strength + this.stats.BendingEnergy) / (1 + this.stats.BendingEnergy);
+    }
+}

--- a/src/player.ts
+++ b/src/player.ts
@@ -24,14 +24,17 @@ type PlayerStats = {
 export class Player {
     stats: PlayerStats;
 
+    // Sets all InnatePlayerStats in stats to 1
     initializeStats() {
        Object.values(InnatePlayerStats).forEach((stat) => { this.stats[stat] = 1; });
     }
 
+    // Increases all InnatePlayerStats in stats by either 0 or 1 (50% chance for either)
     levelUpStats() {
         Object.values(InnatePlayerStats).forEach((stat) => { this.stats[stat] += Math.round(Math.random()); });
     }
 
+    // Re-evalutes the CalculatedPlayerStats in stats
     evaluateCalculatedStats() {
         // TODO: Consider Stats from Items
         // HP


### PR DESCRIPTION
Implementation of the feature "Player Stats".
Stats of items still need to be considered (items not implemented yet).
The Initialize Stats function still has to be called after creating the player instance.
The Level Up Stats function still has to be called after each level up.
The Evaluate Calculated Stats function still has to be called right before every combat encounter.

The merge with this branch is necessary at least for the feature "Items", since they need the defined enums "InnatePlayerStats" and "CalculatedPlayerStats" to specify which stat they increase.